### PR TITLE
修复IIC从机发送数据失败问题。

### DIFF
--- a/AIR001xx_HAL_Driver/Src/air001xx_hal_i2c.c
+++ b/AIR001xx_HAL_Driver/Src/air001xx_hal_i2c.c
@@ -4879,7 +4879,8 @@ void HAL_I2C_ER_IRQHandler(I2C_HandleTypeDef *hi2c)
         ((tmp3 == HAL_I2C_STATE_BUSY_TX) || (tmp3 == HAL_I2C_STATE_BUSY_TX_LISTEN) || \
          ((tmp3 == HAL_I2C_STATE_LISTEN) && (tmp4 == I2C_STATE_SLAVE_BUSY_TX))))
     {
-      I2C_Slave_AF(hi2c);
+      // I2C_Slave_AF(hi2c);
+      I2C_Slave_STOPF(hi2c);
     }
     else
     {


### PR DESCRIPTION
iic从机stop检测在主机最后一字节数据nack的时候不会置位，只会触发nack错误中断。

在NACK错误检测中进行IIC从机的STOP释放，即可修复作为从机发送数据只能发送一次的问题。

使用UNO作为主机，ARI001作为从机进行测试。
![image](https://github.com/Air-duino/Air001-Drivers/assets/6151310/c2451489-05f7-42e1-89c3-19abf593a581)
