### PR TITLE
Fix some warnings

### DIFF
--- a/AIR001xx_HAL_Driver/Inc/air001xx_ll_usart.h
+++ b/AIR001xx_HAL_Driver/Inc/air001xx_ll_usart.h
@@ -998,8 +998,8 @@ __STATIC_INLINE void LL_USART_SetBaudRate(USART_TypeDef *USARTx, uint32_t Periph
   */
 __STATIC_INLINE uint32_t LL_USART_GetBaudRate(USART_TypeDef *USARTx, uint32_t PeriphClk, uint32_t OverSampling)
 {
-  register uint32_t usartdiv = 0x0U;
-  register uint32_t brrresult = 0x0U;
+  uint32_t usartdiv = 0x0U;
+  uint32_t brrresult = 0x0U;
 
   usartdiv = USARTx->BRR;
 

--- a/AIR001xx_HAL_Driver/Src/air001xx_ll_utils.c
+++ b/AIR001xx_HAL_Driver/Src/air001xx_ll_utils.c
@@ -353,7 +353,7 @@ ErrorStatus LL_SetFlashLatency(uint32_t HCLKFrequency)
   /* Frequency cannot be equal to 0 or greater than max clock */
   if ((HCLKFrequency == 0U) || (HCLKFrequency > UTILS_SCALE1_LATENCY2_FREQ))
   {
-    status = ERROR;
+    return ERROR;
   }
   else
   {

--- a/CMSIS/Include/cmsis_gcc.h
+++ b/CMSIS/Include/cmsis_gcc.h
@@ -147,7 +147,7 @@ __attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __get_xPSR(void)
  */
 __attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __get_PSP(void)
 {
-  register uint32_t result;
+  uint32_t result;
 
   __ASM volatile ("MRS %0, psp\n"  : "=r" (result) );
   return(result);
@@ -172,7 +172,7 @@ __attribute__( ( always_inline ) ) __STATIC_INLINE void __set_PSP(uint32_t topOf
  */
 __attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __get_MSP(void)
 {
-  register uint32_t result;
+  uint32_t result;
 
   __ASM volatile ("MRS %0, msp\n" : "=r" (result) );
   return(result);


### PR DESCRIPTION
Fix 2 warnings with my build:
1. `Drivers/CMSIS/Device/AIR001xx/Include/air001xx.h:134:99: warning: 'latency' may be used uninitialized [-Wmaybe-uninitialized]`
2.  `Drivers/CMSIS/Include/cmsis_gcc.h:175:21: warning: ISO C++17 does not allow 'register' storage class specifier [-Wregister]` (refer to ARM-software/CMSIS_5#365)
